### PR TITLE
Add the attrib to all file deletes

### DIFF
--- a/python/meterpreter/ext_server_stdapi.py
+++ b/python/meterpreter/ext_server_stdapi.py
@@ -1240,6 +1240,8 @@ def stdapi_fs_delete_dir(request, response):
 @register_function
 def stdapi_fs_delete_file(request, response):
     file_path = packet_get_tlv(request, TLV_TYPE_FILE_PATH)['value']
+    if has_windll:
+        subprocess.call(unicode("attrib.exe -r ") + file_path)
     os.unlink(unicode(file_path))
     return ERROR_SUCCESS, response
 


### PR DESCRIPTION
During testing I noticed that the function changed in this was not the function that got called on delete for a file on windows 10x64.  Another delete method was called, so I added the attrib change to it, too.  Now it deletes ro files on windows 10x64